### PR TITLE
Update XML.plist

### DIFF
--- a/Syntaxes/XML.plist
+++ b/Syntaxes/XML.plist
@@ -13,6 +13,7 @@
 		<string>dtml</string>
 		<string>rss</string>
 		<string>opml</string>
+		<string>bes</string>
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~X</string>


### PR DESCRIPTION
adding a filetype for a vendor specific XML file. This is for BigFix content XML files.

There are examples here: https://github.com/jgstew/bigfix-content/tree/master/fixlet

They are currently renamed to end with ".xml" in order to have proper syntax highlighting, but ideally they would have the proper syntax highlighting with the ".bes" extension directly since that is how they are used natively. 

I'm not sure if vendor specific filetypes are appropriate or not, or what the alternative is.